### PR TITLE
nornalise repo as per runparts/unixtools examples

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
   build:
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
         fetch-tags: true

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -35,5 +35,5 @@ jobs:
     - name: Test
       run: go test -v -race ./...
 
-    - namee: Test run
+    - name: Test run
       run: ./mkdmg -V

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -34,6 +34,3 @@ jobs:
 
     - name: Test
       run: go test -v -race ./...
-
-    - name: Test run
-      run: ./mkdmg -V

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,17 +14,26 @@ on:
 jobs:
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        fetch-tags: true
 
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
         go-version: 'stable'
 
+    - name: Run go generate
+      run: go generate ./internal/...
+
     - name: Build
       run: go build -v ./...
 
     - name: Test
       run: go test -v -race ./...
+
+    - namee: Test run
+      run: ./mkdmg -V

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+#!/usr/bin/make -f
+
+all: mkdmg check
+
+mkdmg: generate
+	go build
+
+check:
+	go test -v -race ./...
+
+generate: mod-tidy
+	go generate ./internal/...
+
+mod-tidy: go.mod
+	go mod tidy
+
+distclean: clean
+clean:
+	rm -fv mkdmg
+
+.PHONY: all check clean distclean mkdmg mod-tidy generate

--- a/internal/version/.gitignore
+++ b/internal/version/.gitignore
@@ -1,0 +1,1 @@
+version.txt

--- a/internal/version/generate_version.sh
+++ b/internal/version/generate_version.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+SELF_DIR=$(SELF=$(dirname "$0") && bash -c "cd \"$SELF\" && pwd")
+GIT_VERSION=$(git describe --abbrev=6 2>/dev/null || echo "v0.0.0-UNKNOWN")
+echo "${GIT_VERSION}" > "${SELF_DIR}/version.txt"

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,7 @@
+package version
+
+import _ "embed"
+
+//go:generate bash generate_version.sh
+//go:embed version.txt
+var Version string

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 
 	"al.essio.dev/cmd/mkdmg/pkg/hdiutil"
+	"al.essio.dev/cmd/mkdmg/internal/version"
 
 	flag "github.com/spf13/pflag"
 )
@@ -131,6 +132,6 @@ func usage() {
 }
 
 func printVersion() {
-	fmt.Println("mkdmg, version", "UNRELEASED")
+	fmt.Println("mkdmg, version", version.Version)
 	fmt.Println("Copyright (C) 2025 Alessio Treglia <alessio@debian.org>")
 }

--- a/main.go
+++ b/main.go
@@ -1,19 +1,20 @@
 package main
 
 import (
+	"fmt"
 	"io"
 	"log"
 	"os"
+	"path/filepath"
 
 	"al.essio.dev/cmd/mkdmg/pkg/hdiutil"
 
-	"github.com/spf13/pflag"
+	flag "github.com/spf13/pflag"
 )
 
 var (
 	volumeName          string
 	size                int64
-	verbose             bool
 	bless               bool
 	signingIdentity     string
 	notarizeCredentials string
@@ -21,41 +22,64 @@ var (
 	sandboxSafe         bool
 	format              string
 	simulate            bool
+	hdiutilVerbosity    int
 
-	hdiutilVerbosity int
+	helpMode    bool
+	versionMode bool
+	verboseMode bool
+	binBasename string
 
 	verboseLog *log.Logger
 )
 
 func init() {
-	pflag.CommandLine.SetOutput(os.Stderr)
-	log.SetPrefix("mkdmg: ")
-	log.SetFlags(0)
-	log.SetOutput(pflag.CommandLine.Output())
+	binBasename = filepath.Base(os.Args[0])
 
-	pflag.StringVar(&volumeName, "volname", "", "volume name for the DMG")
-	pflag.Int64Var(&size, "disk-image-size", 0, "size for the DMG in MB")
-	pflag.BoolVarP(&verbose, "verbose", "v", false, "enable verbose mode")
-	pflag.StringVar(&signingIdentity, "codesign", "", "signing identity")
-	pflag.BoolVar(&apfsFs, "apfs", false, "use APFS as disk image's filesystem (default: HFS+)")
-	pflag.BoolVar(&sandboxSafe, "sandbox-safe", false, "use sandbox-safe")
-	pflag.StringVar(&format, "format", "", "specify the final disk image format (UDZO|UDBZ|ULFO|ULMO)")
-	pflag.IntVarP(&hdiutilVerbosity, "hdiutil-verbosity", "V", 0, "set hdiutil verbosity level (0=default - 1=quiet - 2=verbose - 3=debug)")
-	pflag.BoolVarP(&simulate, "dry-run", "s", false, "simulate the process")
-	pflag.BoolVar(&bless, "bless", false, "bless the disk image")
-	pflag.StringVar(&notarizeCredentials, "notarize", "", "notarize the disk image (waits and staples) with the keychain stored credentials")
+	flag.CommandLine.SetOutput(os.Stderr)
+
+	flag.StringVar(&volumeName, "volname", "", "volume name for the DMG")
+	flag.Int64Var(&size, "disk-image-size", 0, "size for the DMG in MB")
+	flag.StringVar(&signingIdentity, "codesign", "", "signing identity")
+	flag.BoolVar(&apfsFs, "apfs", false, "use APFS as disk image's filesystem (default: HFS+)")
+	flag.BoolVar(&sandboxSafe, "sandbox-safe", false, "use sandbox-safe")
+	flag.StringVar(&format, "format", "", "specify the final disk image format (UDZO|UDBZ|ULFO|ULMO)")
+	flag.IntVarP(&hdiutilVerbosity, "hdiutil-verbosity", "V", 0, "set hdiutil verbosity level (0=default - 1=quiet - 2=verboseMode - 3=debug)")
+	flag.BoolVarP(&simulate, "dry-run", "s", false, "simulate the process")
+	flag.BoolVar(&bless, "bless", false, "bless the disk image")
+	flag.StringVar(&notarizeCredentials, "notarize", "", "notarize the disk image (waits and staples) with the keychain stored credentials")
+	flag.BoolVarP(&helpMode, "help", "h", false, "display this help and exit.")
+	flag.BoolVarP(&versionMode, "version", "V", false, "output version information and exit.")
+	flag.BoolVarP(&verboseMode, "verboseMode", "v", false, "enable verboseMode mode")
+	flag.Usage = usage
+	flag.ErrHelp = nil
 
 	verboseLog = log.New(io.Discard, "mkdmg: ", 0)
+
+	flag.CommandLine.SetOutput(os.Stderr)
 }
 
 func main() {
-	pflag.Parse()
-	if pflag.NArg() != 2 {
+	log.SetFlags(0)
+	log.SetPrefix(fmt.Sprintf("%s: ", binBasename))
+	log.SetOutput(os.Stderr)
+	flag.Parse()
+
+	if helpMode {
+		usage()
+		return
+	}
+
+	if versionMode {
+		printVersion()
+		return
+	}
+
+	if flag.NArg() != 2 {
 		log.Fatalln("invalid arguments")
 	}
 
-	if verbose {
-		verboseLog.SetOutput(pflag.CommandLine.Output())
+	if verboseMode {
+		verboseLog.SetOutput(os.Stderr)
 		hdiutil.SetLogWriter(os.Stderr)
 	}
 
@@ -69,8 +93,8 @@ func main() {
 		NotarizeCredentials: notarizeCredentials,
 		Simulate:            simulate,
 		Bless:               bless,
-		OutputPath:          pflag.Arg(0),
-		SourceDir:           pflag.Arg(1),
+		OutputPath:          flag.Arg(0),
+		SourceDir:           flag.Arg(1),
 	}
 	if apfsFs {
 		cfg.FileSystem = "APFS"
@@ -99,4 +123,14 @@ func checkErr(err error) {
 	if err != nil {
 		log.Fatal(err)
 	}
+}
+
+func usage() {
+	fmt.Printf("Usage: %s [OPTION]... OUTFILE.DMG DIRECTORY\n", binBasename)
+	fmt.Print(flag.CommandLine.FlagUsages())
+}
+
+func printVersion() {
+	fmt.Println("mkdmg, version", "UNRELEASED")
+	fmt.Println("Copyright (C) 2025 Alessio Treglia <alessio@debian.org>")
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Show version information via a new CLI flag.
  - Improved help/usage output via a help flag.

- **Improvements**
  - More standard CLI flag handling and positional argument parsing.
  - Verbose mode routes extra output to stderr and improves logging prefixes.

- **Chores**
  - Added a Makefile for build, generate, test, and clean tasks.
  - Automated generation and embedding of a version file; updated ignore rules.
  - CI updated to run generation and use macOS runner.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->