### PR TITLE
Update Go toolchain version to 1.26.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,6 @@ module al.essio.dev/cmd/mkdmg
 
 go 1.26
 
-toolchain go1.26.0
+toolchain go1.26.1
 
 require al.essio.dev/pkg/hdiutil v0.1.1-0.20260307073641-fbc4718da097


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go toolchain version to 1.26.1 for build improvements and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->